### PR TITLE
Add jp.dtype 

### DIFF
--- a/jumpy.py
+++ b/jumpy.py
@@ -18,6 +18,7 @@ import numpy as onp
 
 ndarray = Union[onp.ndarray, jnp.ndarray]  # pylint:disable=invalid-name
 tree_map = jax.tree_map  # works great with jax or numpy as-is
+dtype = onp.dtype
 pi = onp.pi
 inf = onp.inf
 float32 = onp.float32


### PR DESCRIPTION
For new dev_wrappers of gym which uses Jumpy, jp.dtype is useful for type hinting 
@pseudo-rnd-thoughts