### PR TITLE
Indexing according to jax API

### DIFF
--- a/jumpy/__init__.py
+++ b/jumpy/__init__.py
@@ -24,6 +24,7 @@ except ImportError:
 
 from jumpy import lax, ops, random
 from jumpy._base_fns import index_update, vmap
+from jumpy._indexing import jparray
 
 __all__ = [
     # === primitives ===
@@ -33,6 +34,7 @@ __all__ = [
     "float32",
     "int32",
     "ndarray",
+    "jparray",
     # === sub-modules ===
     "random",
     "numpy",

--- a/jumpy/_indexing.py
+++ b/jumpy/_indexing.py
@@ -1,0 +1,184 @@
+import numpy as onp
+import jumpy
+
+if jumpy.is_jax_installed:
+    import jax
+    import jax._src.numpy.lax_numpy as lax_numpy
+
+
+    def jumpy_view(arr, maybe_subtype, *args, **kwargs):
+        if maybe_subtype == jparray:
+            return arr
+        else:
+            return lax_numpy._view(arr, maybe_subtype, *args, **kwargs)
+
+    # import jaxlib.xla_extension contains more arrays --> overwrite view?
+    # import jax._src.array contains more arrays --> overwrite view?
+    lax_numpy.ShapedArray.view = jumpy_view
+    lax_numpy.DShapedArray.view = jumpy_view
+    lax_numpy.device_array.DeviceArray.view = jumpy_view
+    lax_numpy.ArrayImpl.view = jumpy_view
+    jax.Array.view = jumpy_view
+
+
+class jparray(onp.ndarray):
+    """A numpy.ndarray with additional JAX methods.
+    Based on: https://numpy.org/doc/stable/user/basics.subclassing.html#simple-example-adding-an-extra-attribute-to-ndarray
+    """
+
+    def __array_finalize__(self, obj):
+        # Only do this for numpy arrays
+        if isinstance(obj, onp.ndarray):
+            setattr(self, "at", _IndexUpdateHelper(self))
+
+
+class _IndexUpdateHelper(lax_numpy._IndexUpdateHelper):
+    def __getitem__(self, index):
+        return _IndexUpdateRef(self.array, index)
+
+
+class _IndexUpdateRef:
+    """Helper object to call indexed update functions for an (advanced) index.
+
+    This object references a source array and a specific indexer into that array.
+    Methods on this object return copies of the source array that have been
+    modified at the positions specified by the indexer.
+    """
+    __slots__ = ("array", "index")
+
+    def __init__(self, array, index):
+        self.array = array
+        self.index = index
+
+    def __repr__(self):
+        return f"_IndexUpdateRef({repr(self.array)}, {repr(self.index)})"
+
+    def get(self, indices_are_sorted=False, unique_indices=False, mode=None, fill_value=None):
+        """Equivalent to ``x[idx]``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:indexing <numpy.doc.indexing>` ``x[idx]``. This function differs from
+        the usual array indexing syntax in that it allows additional keyword
+        arguments ``indices_are_sorted`` and ``unique_indices`` to be passed.
+
+        See :mod:`jax.ops` for details.
+        """
+        return self.array[self.index]
+
+    def set(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``x[idx] = y``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:`indexed assignment <numpy.doc.indexing>` ``x[idx] = y``.
+
+        See :mod:`jax.ops` for details.
+        """
+        array_copy = self.array.copy()
+        array_copy[self.index] = values
+        return array_copy
+
+    def apply(self, func, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``func.at(x, idx)`` for a unary ufunc ``func``.
+
+        Returns the value of ``x`` that would result from applying the unary
+        function ``func`` to ``x`` at the given indices. This is similar to
+        ``x.at[idx].set(func(x[idx]))``, but differs in the case of repeated indices:
+        in ``x.at[idx].apply(func)``, repeated indices result in the function being
+        applied multiple times.
+
+        Note that in the current implementation, ``scatter_apply`` is not compatible
+        with automatic differentiation.
+
+        See :mod:`jax.ops` for details.
+        """
+        raise NotImplementedError("Not implemented yet. Seems that jax API has a bug. "
+                                  "jax_arr.at[1:2].apply(lambda x: x + 1) works, but"
+                                  "jax_arr.at[2].apply(lambda x: x + 1) raises an error.")
+        # array_copy = self.array.copy()
+        # array_copy[self.index] = func(array_copy[self.index])
+        # return array_copy
+
+    def add(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``x[idx] += y``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] += y``.
+
+        See :mod:`jax.ops` for details.
+        """
+        array_copy = self.array.copy()
+        array_copy[self.index] += values
+        return array_copy
+
+    def multiply(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``x[idx] *= y``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] *= y``.
+
+        See :mod:`jax.ops` for details.
+        """
+        array_copy = self.array.copy()
+        array_copy[self.index] *= values
+        return array_copy
+
+    mul = multiply
+
+    def divide(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``x[idx] /= y``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] /= y``.
+
+        See :mod:`jax.ops` for details.
+        """
+        # !NOTE: jax division seems to cast array to float32. This is not the case for ``x[idx] /= y`` with numpy.
+        # _v = values if hasattr(onp.float32(values), "__len__") else float(values)
+        array_copy = self.array.astype("float32", copy=True)
+        array_copy[self.index] /= onp.array(values)
+        return array_copy
+
+    def power(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``x[idx] **= y``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:indexed assignment <numpy.doc.indexing>` ``x[idx] **= y``.
+
+        See :mod:`jax.ops` for details.
+        """
+        # _v = values if hasattr(onp.float32(values), "__len__") else [values]
+        # if any([v < 0 for v in _v]):
+        # 	array_copy = self.array.astype("float32", copy=True)
+        # else:
+        # 	array_copy = self.array.copy()
+        # !NOTE: Strange jax behavior for integers with negative powers. We raise an error for now in that case.
+        #   Can be reproduced with jax.numpy.arange(10).at[-1].power(-2) = array([0, 1, 2, 3, 4, 5, 6, 7, 8, -77356367], dtype=int32)
+        array_copy = self.array.copy()
+        array_copy[self.index] **= values #onp.power(array_copy[self.index], values)
+        return array_copy
+
+    def min(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``x[idx] = minimum(x[idx], y)``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:indexed assignment <numpy.doc.indexing>`
+        ``x[idx] = minimum(x[idx], y)``.
+
+        See :mod:`jax.ops` for details.
+        """
+        array_copy = self.array.copy()
+        array_copy[self.index] = onp.minimum(array_copy[self.index], values)
+        return array_copy
+
+    def max(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+        """Pure equivalent of ``x[idx] = maximum(x[idx], y)``.
+
+        Returns the value of ``x`` that would result from the NumPy-style
+        :mod:indexed assignment <numpy.doc.indexing>`
+        ``x[idx] = maximum(x[idx], y)``.
+
+        See :mod:`jax.ops` for details.
+        """
+        array_copy = self.array.copy()
+        array_copy[self.index] = onp.maximum(array_copy[self.index], values)
+        return array_copy

--- a/jumpy/_indexing.py
+++ b/jumpy/_indexing.py
@@ -7,6 +7,10 @@ if jumpy.is_jax_installed:
     import jax._src.numpy.lax_numpy as lax_numpy
 
     def jumpy_view(arr, maybe_subtype, *args, **kwargs):
+        """This serves as a NOOP decorator for all jax array `.view` methods.
+
+        Unfortunately, jax arrays already have a `.view` method. To allow jumpy users to call `.view` on jax arrays when they
+        intend to use jumpy, we need to override the jax `.view` method with a NOOP decorator."""
         if maybe_subtype == jparray:
             return arr
         else:
@@ -23,10 +27,16 @@ if jumpy.is_jax_installed:
 
 class jparray(onp.ndarray):
     """A numpy.ndarray with additional JAX methods.
+
     Based on: https://numpy.org/doc/stable/user/basics.subclassing.html#simple-example-adding-an-extra-attribute-to-ndarray
     """
 
     def __array_finalize__(self, obj):
+        """This method is the mechanism that numpy provides to allow this subclass to handle how new instances get created.
+
+        More info on the role of this method can be found here:
+        https://numpy.org/doc/stable/user/basics.subclassing.html#the-role-of-array-finalize
+        """
         # Only do this for numpy arrays
         if isinstance(obj, onp.ndarray):
             setattr(self, "at", _IndexUpdateHelper(self))

--- a/jumpy/_indexing.py
+++ b/jumpy/_indexing.py
@@ -1,10 +1,10 @@
 import numpy as onp
+
 import jumpy
 
 if jumpy.is_jax_installed:
     import jax
     import jax._src.numpy.lax_numpy as lax_numpy
-
 
     def jumpy_view(arr, maybe_subtype, *args, **kwargs):
         if maybe_subtype == jparray:
@@ -34,100 +34,101 @@ class jparray(onp.ndarray):
 
 # Note: this docstring will appear as the docstring for the `at` property.
 class _IndexUpdateHelper:
-  """Helper property for index update functionality.
+    """Helper property for index update functionality.
 
-  The ``at`` property provides a functionally pure equivalent of in-place
-  array modificatons.
+    The ``at`` property provides a functionally pure equivalent of in-place
+    array modificatons.
 
-  In particular:
+    In particular:
 
-  ==============================  ================================
-  Alternate syntax                Equivalent In-place expression
-  ==============================  ================================
-  ``x = x.at[idx].set(y)``        ``x[idx] = y``
-  ``x = x.at[idx].add(y)``        ``x[idx] += y``
-  ``x = x.at[idx].multiply(y)``   ``x[idx] *= y``
-  ``x = x.at[idx].divide(y)``     ``x[idx] /= y``
-  ``x = x.at[idx].power(y)``      ``x[idx] **= y``
-  ``x = x.at[idx].min(y)``        ``x[idx] = minimum(x[idx], y)``
-  ``x = x.at[idx].max(y)``        ``x[idx] = maximum(x[idx], y)``
-  ``x = x.at[idx].apply(ufunc)``  ``ufunc.at(x, idx)``
-  ``x = x.at[idx].get()``         ``x = x[idx]``
-  ==============================  ================================
+    ==============================  ================================
+    Alternate syntax                Equivalent In-place expression
+    ==============================  ================================
+    ``x = x.at[idx].set(y)``        ``x[idx] = y``
+    ``x = x.at[idx].add(y)``        ``x[idx] += y``
+    ``x = x.at[idx].multiply(y)``   ``x[idx] *= y``
+    ``x = x.at[idx].divide(y)``     ``x[idx] /= y``
+    ``x = x.at[idx].power(y)``      ``x[idx] **= y``
+    ``x = x.at[idx].min(y)``        ``x[idx] = minimum(x[idx], y)``
+    ``x = x.at[idx].max(y)``        ``x[idx] = maximum(x[idx], y)``
+    ``x = x.at[idx].apply(ufunc)``  ``ufunc.at(x, idx)``
+    ``x = x.at[idx].get()``         ``x = x[idx]``
+    ==============================  ================================
 
-  None of the ``x.at`` expressions modify the original ``x``; instead they return
-  a modified copy of ``x``. However, inside a :py:func:`~jax.jit` compiled function,
-  expressions like :code:`x = x.at[idx].set(y)` are guaranteed to be applied in-place.
+    None of the ``x.at`` expressions modify the original ``x``; instead they return
+    a modified copy of ``x``. However, inside a :py:func:`~jax.jit` compiled function,
+    expressions like :code:`x = x.at[idx].set(y)` are guaranteed to be applied in-place.
 
-  Unlike NumPy in-place operations such as :code:`x[idx] += y`, if multiple
-  indices refer to the same location, all updates will be applied (NumPy would
-  only apply the last update, rather than applying all updates.) The order
-  in which conflicting updates are applied is implementation-defined and may be
-  nondeterministic (e.g., due to concurrency on some hardware platforms).
+    Unlike NumPy in-place operations such as :code:`x[idx] += y`, if multiple
+    indices refer to the same location, all updates will be applied (NumPy would
+    only apply the last update, rather than applying all updates.) The order
+    in which conflicting updates are applied is implementation-defined and may be
+    nondeterministic (e.g., due to concurrency on some hardware platforms).
 
-  By default, JAX assumes that all indices are in-bounds. There is experimental
-  support for giving more precise semantics to out-of-bounds indexed accesses,
-  via the ``mode`` parameter (see below).
+    By default, JAX assumes that all indices are in-bounds. There is experimental
+    support for giving more precise semantics to out-of-bounds indexed accesses,
+    via the ``mode`` parameter (see below).
 
-  Arguments
-  ---------
-  mode : str
-      Specify out-of-bound indexing mode. Options are:
+    Arguments
+    ---------
+    mode : str
+        Specify out-of-bound indexing mode. Options are:
 
-      - ``"promise_in_bounds"``: (default) The user promises that indices are in bounds.
-        No additional checking will be performed. In practice, this means that
-        out-of-bounds indices in ``get()`` will be clipped, and out-of-bounds indices
-        in ``set()``, ``add()``, etc. will be dropped.
-      - ``"clip"``: clamp out of bounds indices into valid range.
-      - ``"drop"``: ignore out-of-bound indices.
-      - ``"fill"``: alias for ``"drop"``.  For `get()`, the optional ``fill_value``
-        argument specifies the value that will be returned.
+        - ``"promise_in_bounds"``: (default) The user promises that indices are in bounds.
+          No additional checking will be performed. In practice, this means that
+          out-of-bounds indices in ``get()`` will be clipped, and out-of-bounds indices
+          in ``set()``, ``add()``, etc. will be dropped.
+        - ``"clip"``: clamp out of bounds indices into valid range.
+        - ``"drop"``: ignore out-of-bound indices.
+        - ``"fill"``: alias for ``"drop"``.  For `get()`, the optional ``fill_value``
+          argument specifies the value that will be returned.
 
-        See :class:`jax.lax.GatherScatterMode` for more details.
+          See :class:`jax.lax.GatherScatterMode` for more details.
 
-  indices_are_sorted : bool
-      If True, the implementation will assume that the indices passed to ``at[]``
-      are sorted in ascending order, which can lead to more efficient execution
-      on some backends.
-  unique_indices : bool
-      If True, the implementation will assume that the indices passed to ``at[]``
-      are unique, which can result in more efficient execution on some backends.
-  fill_value : Any
-      Only applies to the ``get()`` method: the fill value to return for out-of-bounds
-      slices when `mode` is ``'fill'``. Ignored otherwise. Defaults to ``NaN`` for
-      inexact types, the largest negative value for signed types, the largest positive
-      value for unsigned types, and ``True`` for booleans.
+    indices_are_sorted : bool
+        If True, the implementation will assume that the indices passed to ``at[]``
+        are sorted in ascending order, which can lead to more efficient execution
+        on some backends.
+    unique_indices : bool
+        If True, the implementation will assume that the indices passed to ``at[]``
+        are unique, which can result in more efficient execution on some backends.
+    fill_value : Any
+        Only applies to the ``get()`` method: the fill value to return for out-of-bounds
+        slices when `mode` is ``'fill'``. Ignored otherwise. Defaults to ``NaN`` for
+        inexact types, the largest negative value for signed types, the largest positive
+        value for unsigned types, and ``True`` for booleans.
 
-  Examples
-  --------
-  >>> x = jnp.arange(5.0)
-  >>> x
-  DeviceArray([0., 1., 2., 3., 4.], dtype=float32)
-  >>> x.at[2].add(10)
-  DeviceArray([ 0.,  1., 12.,  3.,  4.], dtype=float32)
-  >>> x.at[10].add(10)  # out-of-bounds indices are ignored
-  DeviceArray([0., 1., 2., 3., 4.], dtype=float32)
-  >>> x.at[20].add(10, mode='clip')
-  DeviceArray([ 0.,  1.,  2.,  3., 14.], dtype=float32)
-  >>> x.at[2].get()
-  DeviceArray(2., dtype=float32)
-  >>> x.at[20].get()  # out-of-bounds indices clipped
-  DeviceArray(4., dtype=float32)
-  >>> x.at[20].get(mode='fill')  # out-of-bounds indices filled with NaN
-  DeviceArray(nan, dtype=float32)
-  >>> x.at[20].get(mode='fill', fill_value=-1)  # custom fill value
-  DeviceArray(-1., dtype=float32)
-  """
-  __slots__ = ("array",)
+    Examples
+    --------
+    >>> x = jnp.arange(5.0)
+    >>> x
+    DeviceArray([0., 1., 2., 3., 4.], dtype=float32)
+    >>> x.at[2].add(10)
+    DeviceArray([ 0.,  1., 12.,  3.,  4.], dtype=float32)
+    >>> x.at[10].add(10)  # out-of-bounds indices are ignored
+    DeviceArray([0., 1., 2., 3., 4.], dtype=float32)
+    >>> x.at[20].add(10, mode='clip')
+    DeviceArray([ 0.,  1.,  2.,  3., 14.], dtype=float32)
+    >>> x.at[2].get()
+    DeviceArray(2., dtype=float32)
+    >>> x.at[20].get()  # out-of-bounds indices clipped
+    DeviceArray(4., dtype=float32)
+    >>> x.at[20].get(mode='fill')  # out-of-bounds indices filled with NaN
+    DeviceArray(nan, dtype=float32)
+    >>> x.at[20].get(mode='fill', fill_value=-1)  # custom fill value
+    DeviceArray(-1., dtype=float32)
+    """
 
-  def __init__(self, array):
-    self.array = array
+    __slots__ = ("array",)
 
-  def __getitem__(self, index):
-    return _IndexUpdateRef(self.array, index)
+    def __init__(self, array):
+        self.array = array
 
-  def __repr__(self):
-    return f"_IndexUpdateHelper({repr(self.array)})"
+    def __getitem__(self, index):
+        return _IndexUpdateRef(self.array, index)
+
+    def __repr__(self):
+        return f"_IndexUpdateHelper({repr(self.array)})"
 
 
 class _IndexUpdateRef:
@@ -137,6 +138,7 @@ class _IndexUpdateRef:
     Methods on this object return copies of the source array that have been
     modified at the positions specified by the indexer.
     """
+
     __slots__ = ("array", "index")
 
     def __init__(self, array, index):
@@ -146,7 +148,9 @@ class _IndexUpdateRef:
     def __repr__(self):
         return f"_IndexUpdateRef({repr(self.array)}, {repr(self.index)})"
 
-    def get(self, indices_are_sorted=False, unique_indices=False, mode=None, fill_value=None):
+    def get(
+        self, indices_are_sorted=False, unique_indices=False, mode=None, fill_value=None
+    ):
         """Equivalent to ``x[idx]``.
 
         Returns the value of ``x`` that would result from the NumPy-style
@@ -184,9 +188,11 @@ class _IndexUpdateRef:
 
         See :mod:`jax.ops` for details.
         """
-        raise NotImplementedError("Not implemented yet. Seems that jax API has a bug. "
-                                  "jax_arr.at[1:2].apply(lambda x: x + 1) works, but"
-                                  "jax_arr.at[2].apply(lambda x: x + 1) raises an error.")
+        raise NotImplementedError(
+            "Not implemented yet. Seems that jax API has a bug. "
+            "jax_arr.at[1:2].apply(lambda x: x + 1) works, but"
+            "jax_arr.at[2].apply(lambda x: x + 1) raises an error."
+        )
         # array_copy = self.array.copy()
         # array_copy[self.index] = func(array_copy[self.index])
         # return array_copy
@@ -203,7 +209,9 @@ class _IndexUpdateRef:
         array_copy[self.index] += values
         return array_copy
 
-    def multiply(self, values, indices_are_sorted=False, unique_indices=False, mode=None):
+    def multiply(
+        self, values, indices_are_sorted=False, unique_indices=False, mode=None
+    ):
         """Pure equivalent of ``x[idx] *= y``.
 
         Returns the value of ``x`` that would result from the NumPy-style
@@ -247,7 +255,7 @@ class _IndexUpdateRef:
         # !NOTE: Strange jax behavior for integers with negative powers. We raise an error for now in that case.
         #   Can be reproduced with jax.numpy.arange(10).at[-1].power(-2) = array([0, 1, 2, 3, 4, 5, 6, 7, 8, -77356367], dtype=int32)
         array_copy = self.array.copy()
-        array_copy[self.index] **= values #onp.power(array_copy[self.index], values)
+        array_copy[self.index] **= values  # onp.power(array_copy[self.index], values)
         return array_copy
 
     def min(self, values, indices_are_sorted=False, unique_indices=False, mode=None):

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,0 +1,56 @@
+import jumpy
+import numpy as onp
+import jax
+
+
+def test_indexing():
+	# Prepare two different arrays for testing
+	a = onp.arange(0, 10)
+	b = jax.numpy.arange(0, 10)
+
+	# Check view casting (https://numpy.org/doc/stable/user/basics.subclassing.html#view-casting)
+	a_jp = a.view(jumpy.jparray)
+	b_jp = b.view(jumpy.jparray)
+
+	# Check template casting (https://numpy.org/doc/stable/user/basics.subclassing.html#creating-new-from-template)
+	a2_jp = a_jp[:2]
+	b2_jp = b_jp[:2]
+	assert isinstance(b2_jp, jax.Array)
+	assert isinstance(a2_jp, jumpy.jparray)
+
+	# Use this util to get indices from slice
+	class Indexer:
+		def __getitem__(self, item):
+			if isinstance(item, slice):
+				return list(range(item.stop)[item])
+
+	indexer = Indexer()
+
+	# Test settiing values
+	slices = [2, slice(1, 2), slice(1, 5)]
+	for sl in slices:
+		# Test API for scalar
+		assert onp.isclose(a_jp.at[sl].get(-2), b_jp.at[sl].get(-2)).all()
+		assert onp.isclose(a_jp.at[sl].set(-2), b_jp.at[sl].set(-2)).all()
+		assert onp.isclose(a_jp.at[sl].add(-1), b_jp.at[sl].add(-1)).all()
+		assert onp.isclose(a_jp.at[sl].mul(-2), b_jp.at[sl].mul(-2)).all()
+		assert onp.isclose(a_jp.at[sl].divide(-2), b_jp.at[sl].divide(-2)).all()
+		assert onp.isclose(a_jp.at[sl].power(2), b_jp.at[sl].power(2)).all()
+		assert onp.isclose(a_jp.at[sl].min(-2), b_jp.at[sl].min(-2)).all()
+		assert onp.isclose(a_jp.at[sl].max(-2), b_jp.at[sl].max(-2)).all()
+
+		# Test API for array setting
+		ind = indexer[sl]
+		val = ind if ind is not None else 2
+		assert onp.isclose(a_jp.at[sl].get(val), b_jp.at[sl].get(val)).all()
+		assert onp.isclose(a_jp.at[sl].set(val), b_jp.at[sl].set(val)).all()
+		assert onp.isclose(a_jp.at[sl].add(val), b_jp.at[sl].add(val)).all()
+		assert onp.isclose(a_jp.at[sl].mul(val), b_jp.at[sl].mul(val)).all()
+		assert onp.isclose(a_jp.at[sl].divide(val), b_jp.at[sl].divide(val)).all()
+		assert onp.isclose(a_jp.at[sl].power(val), b_jp.at[sl].power(val)).all()
+		assert onp.isclose(a_jp.at[sl].min(val), b_jp.at[sl].min(val)).all()
+		assert onp.isclose(a_jp.at[sl].max(val), b_jp.at[sl].max(val)).all()
+
+
+if __name__ == "__main__":
+	test_indexing()

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,3 +1,4 @@
+"""Test indexing on numpy arrays according to jax array index API."""
 import jax
 import numpy as onp
 
@@ -5,6 +6,7 @@ import jumpy
 
 
 def test_indexing():
+    """Test indexing on numpy arrays according to jax array index API."""
     # Prepare two different arrays for testing
     a = onp.arange(0, 10)
     b = jax.numpy.arange(0, 10)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,56 +1,57 @@
-import jumpy
-import numpy as onp
 import jax
+import numpy as onp
+
+import jumpy
 
 
 def test_indexing():
-	# Prepare two different arrays for testing
-	a = onp.arange(0, 10)
-	b = jax.numpy.arange(0, 10)
+    # Prepare two different arrays for testing
+    a = onp.arange(0, 10)
+    b = jax.numpy.arange(0, 10)
 
-	# Check view casting (https://numpy.org/doc/stable/user/basics.subclassing.html#view-casting)
-	a_jp = a.view(jumpy.jparray)
-	b_jp = b.view(jumpy.jparray)
+    # Check view casting (https://numpy.org/doc/stable/user/basics.subclassing.html#view-casting)
+    a_jp = a.view(jumpy.jparray)
+    b_jp = b.view(jumpy.jparray)
 
-	# Check template casting (https://numpy.org/doc/stable/user/basics.subclassing.html#creating-new-from-template)
-	a2_jp = a_jp[:2]
-	b2_jp = b_jp[:2]
-	assert isinstance(b2_jp, jax.Array)
-	assert isinstance(a2_jp, jumpy.jparray)
+    # Check template casting (https://numpy.org/doc/stable/user/basics.subclassing.html#creating-new-from-template)
+    a2_jp = a_jp[:2]
+    b2_jp = b_jp[:2]
+    assert isinstance(b2_jp, jax.Array)
+    assert isinstance(a2_jp, jumpy.jparray)
 
-	# Use this util to get indices from slice
-	class Indexer:
-		def __getitem__(self, item):
-			if isinstance(item, slice):
-				return list(range(item.stop)[item])
+    # Use this util to get indices from slice
+    class Indexer:
+        def __getitem__(self, item):
+            if isinstance(item, slice):
+                return list(range(item.stop)[item])
 
-	indexer = Indexer()
+    indexer = Indexer()
 
-	# Test settiing values
-	slices = [2, slice(1, 2), slice(1, 5)]
-	for sl in slices:
-		# Test API for scalar
-		assert onp.isclose(a_jp.at[sl].get(-2), b_jp.at[sl].get(-2)).all()
-		assert onp.isclose(a_jp.at[sl].set(-2), b_jp.at[sl].set(-2)).all()
-		assert onp.isclose(a_jp.at[sl].add(-1), b_jp.at[sl].add(-1)).all()
-		assert onp.isclose(a_jp.at[sl].mul(-2), b_jp.at[sl].mul(-2)).all()
-		assert onp.isclose(a_jp.at[sl].divide(-2), b_jp.at[sl].divide(-2)).all()
-		assert onp.isclose(a_jp.at[sl].power(2), b_jp.at[sl].power(2)).all()
-		assert onp.isclose(a_jp.at[sl].min(-2), b_jp.at[sl].min(-2)).all()
-		assert onp.isclose(a_jp.at[sl].max(-2), b_jp.at[sl].max(-2)).all()
+    # Test settiing values
+    slices = [2, slice(1, 2), slice(1, 5)]
+    for sl in slices:
+        # Test API for scalar
+        assert onp.isclose(a_jp.at[sl].get(-2), b_jp.at[sl].get(-2)).all()
+        assert onp.isclose(a_jp.at[sl].set(-2), b_jp.at[sl].set(-2)).all()
+        assert onp.isclose(a_jp.at[sl].add(-1), b_jp.at[sl].add(-1)).all()
+        assert onp.isclose(a_jp.at[sl].mul(-2), b_jp.at[sl].mul(-2)).all()
+        assert onp.isclose(a_jp.at[sl].divide(-2), b_jp.at[sl].divide(-2)).all()
+        assert onp.isclose(a_jp.at[sl].power(2), b_jp.at[sl].power(2)).all()
+        assert onp.isclose(a_jp.at[sl].min(-2), b_jp.at[sl].min(-2)).all()
+        assert onp.isclose(a_jp.at[sl].max(-2), b_jp.at[sl].max(-2)).all()
 
-		# Test API for array setting
-		ind = indexer[sl]
-		val = ind if ind is not None else 2
-		assert onp.isclose(a_jp.at[sl].get(val), b_jp.at[sl].get(val)).all()
-		assert onp.isclose(a_jp.at[sl].set(val), b_jp.at[sl].set(val)).all()
-		assert onp.isclose(a_jp.at[sl].add(val), b_jp.at[sl].add(val)).all()
-		assert onp.isclose(a_jp.at[sl].mul(val), b_jp.at[sl].mul(val)).all()
-		assert onp.isclose(a_jp.at[sl].divide(val), b_jp.at[sl].divide(val)).all()
-		assert onp.isclose(a_jp.at[sl].power(val), b_jp.at[sl].power(val)).all()
-		assert onp.isclose(a_jp.at[sl].min(val), b_jp.at[sl].min(val)).all()
-		assert onp.isclose(a_jp.at[sl].max(val), b_jp.at[sl].max(val)).all()
+        # Test API for array setting
+        ind = indexer[sl]
+        val = ind if ind is not None else 2
+        assert onp.isclose(a_jp.at[sl].get(val), b_jp.at[sl].get(val)).all()
+        assert onp.isclose(a_jp.at[sl].set(val), b_jp.at[sl].set(val)).all()
+        assert onp.isclose(a_jp.at[sl].add(val), b_jp.at[sl].add(val)).all()
+        assert onp.isclose(a_jp.at[sl].mul(val), b_jp.at[sl].mul(val)).all()
+        assert onp.isclose(a_jp.at[sl].divide(val), b_jp.at[sl].divide(val)).all()
+        assert onp.isclose(a_jp.at[sl].power(val), b_jp.at[sl].power(val)).all()
+        assert onp.isclose(a_jp.at[sl].min(val), b_jp.at[sl].min(val)).all()
+        assert onp.isclose(a_jp.at[sl].max(val), b_jp.at[sl].max(val)).all()
 
 
 if __name__ == "__main__":
-	test_indexing()
+    test_indexing()


### PR DESCRIPTION
This PR allows users to take a `view` on `onp.ndarray` that allows users to use the JAX API for array indexing. This means that the `.at[idx].set(val)` API can be used on numpy arrays. 

A subclass of `numpy.array` was added following [this](https://numpy.org/doc/stable/user/basics.subclassing.html#creating-new-from-template) procedure, that basically adds the `add` property with all the necessary functionality. 

This API is completely optional, thus only available once they have converted their `onp.array` to `jumpy.jparray` by taking a `view` on their array (does not copy data). The subclass is compatible with any numpy method. Furthermore, once a numpy method is applied, it will also return the subclass instead of reverting back to a `onp.array`. This is demonstrated below:

```python
import jumpy
import numpy as onp
import jax.numpy as jnp

# Construct numpy array
arr = onp.arange(10)  
# arr.at[0].set(1) --> fails, because a regular numpy array does not yet have the .at property

# Create a `view` on the numpy array that has the .at property (does not copy).
arr_jp = arr.view(jumpy.jparray)

# Mimics jax API for numpy arrays
new_arr = arr_jp.at[0].set(1)   # Makes a copy, similar to array indexing with jax.
another_arr = onp.add(arr_jp, 1)  # Every ordinary numpy method can still be applied "as-is" on the subclass.
hasattr(another_arr, "at")  # --> True, because of type casting.

# In `jumpy._indexing.py` we decorate the existing .view methods of jax arrays, 
# so that it matches the functionality of the numpy `.view` API.
arr = jnp.arange(10)
arr.at[0].set(1)  # --> Already works out of the box for jax arrays
arr_jp = arr.view(jumpy.jparray)  # --> Nevertheless, users may still call `.view(jumpy.jparray)` which will then be a NOOP.

# In case the array type is unsure (jax/numpy), which is often the case in jumpy code, 
# while a user still wants to use the `at[idx].set(val)` API, even for numpy arrays,
# the user can call `.view(jumpy.jparray)` on the array, before the `at[idx].set(val)` API, to ensure it is available.
```


See [here](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#in-place-updates) for more info on in-place updates with jax.

Some open questions:

1. Not sure about the subclass name `jparray`. Ideally, it would be `ndarray`, but that already exists as a variable for typing.
2.  Should we then remove the custom function `_base_fns.index_update`, or keep it?
3.  Should all the `_factory_fns` per default call `.view(jp.jparray)` such that the `.view(jp.jparray)` calls are mostly abstracted away from the users. Users will then only ever require to call `.view(jp.jparray)` when they create an array explicitly with `onp.array` and they want to use the `.at[idx].set(o)` API. 
